### PR TITLE
Enable pcs on Debian family

### DIFF
--- a/manifests/ha/pacemaker.pp
+++ b/manifests/ha/pacemaker.pp
@@ -79,6 +79,7 @@ class lizardfs::ha::pacemaker(
     authkey                    => "/var/lib/puppet/ssl/certs/ca.pem",
     bind_address               => $ipaddress,
     multicast_address          => $multicast_address,
+    package_pcs                => true,
     manage_pcsd_service        => true,
     # debug                      => true,
     set_votequorum             => true,


### PR DESCRIPTION
It should repair the Error: Could not find dependency Package[pcs] for Service[pcsd] at /opt/data/puppet/modules/corosync/manifests/init.pp:357